### PR TITLE
command/spinup: add more hooks

### DIFF
--- a/lib/einhorn.rb
+++ b/lib/einhorn.rb
@@ -88,7 +88,10 @@ module Einhorn
         drop_environment_variables: [],
         signal_timeout: nil,
         preloaded: false,
+        on_pre_fork: nil,
+        on_new_child_item: nil,
         execute_proc: nil,
+        on_cleanup: nil,
         run_once: false
       }
     end


### PR DESCRIPTION
added spinup_fork, on_new_child, execute_proc, on_cleanup.
needed to implement statically allocated cgroups handling.